### PR TITLE
make utility function use factory for DB and fix unittest

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2293,8 +2293,6 @@ CREATE TABLE `Project` (
     `recruitmentTarget` INT(6) Default NULL,
     PRIMARY KEY (`ProjectID`)
 )ENGINE = InnoDB  DEFAULT CHARSET=utf8;
-INSERT INTO Project (ProjectID, Name, recruitmentTarget) VALUES (1, 'Sample Project', 50);
-INSERT INTO Project (ProjectID, Name, recruitmentTarget) VALUES (2, 'Another Sample Project', 50);
 
 CREATE TABLE StatisticsTabs(
     ID INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -276,8 +276,8 @@ class Utility extends PEAR
      */
     static function getProjectList()
     {
-        $DB     = Database::singleton();
-        $config = NDB_Config::singleton();
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
         // get the list of projects
         $projects = $DB->pselect("SELECT * FROM Project", array());
         $project  = array();

--- a/test/unittests/api/v0.0.1/Projects_Test.php
+++ b/test/unittests/api/v0.0.1/Projects_Test.php
@@ -17,11 +17,30 @@ class Projects_Test extends BaseTestCase
         $this->Factory->setTesting(true);
 
         $this->Config = $this->Factory->config();
-
+        $this->Database = $this->Factory->database();
 
 
         $this->getMockBuilder('NDB_Config')->setMockClassName("MockNDB_Config")->getMock();
         $this->getMockBuilder('Database')->setMockClassName("MockDatabase")->getMock();
+
+        $this->Database->method("pselect")->will($this->returnCallback(
+            function ($query, $params) {
+                if($query == "SELECT * FROM Project") {
+                    return [
+                        [
+                            "ProjectID" => 1,
+                            "Name" => "Sample Project"
+                        ],
+                        [
+                            "ProjectID" => 2,
+                            "Name" => "Another Sample Project"
+                        ]
+                    ];
+                }
+
+                return array();
+            }
+        ));
 
         /*
         $this->Config->method("getSetting")->will($this->returnCallback(
@@ -176,20 +195,6 @@ class Projects_Test extends BaseTestCase
                                         ]
                                     ]
                                 ]
-                    ];
-                }
-                if($arg === 'Projects') {
-                    return [
-                        "project" => [
-                            [
-                                "id" => 1,
-                                "title" => "Sample Project"
-                            ],
-                            [
-                                    "id" => 2,
-                                    "title" => "Another Sample Project"
-                            ]
-                        ]
                     ];
                 }
                 return null;


### PR DESCRIPTION
Merge this into your branch. It makes the Utility function you wrote use the Factory DB so that the unit test can use a mock DB. It also fixes the unit test to use the mock DB as opposed to the actual DB
